### PR TITLE
Allow loadSnapshot to return a promise that resolves to undefined

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,9 @@ export interface StreamSnapshot extends Snapshot, StreamData {
 
 export type Fns = {
   unpack(x: Uint8Array): any
-  loadSnapshot(topologyId: string): Promise<Snapshot> | Snapshot | undefined
+  loadSnapshot(
+    topologyId: string
+  ): Promise<Snapshot | undefined> | Snapshot | undefined
   persistSnapshot(topologyId: string, snapshot: StreamSnapshot): void
   shouldResume?(topologyId: string): Promise<boolean> | boolean
   getTopologyId?(msg: JsMsg): string


### PR DESCRIPTION
Since `loadSnapshot` may not load one