### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.1
+
+* Allow `loadSnapshot` to return a promise that resolves to undefined
+
 # 0.7.0
 
 * Latest `topology-runner`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nats-topology-runner",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nats-topology-runner",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats-topology-runner",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Run a topology created with topology-runner using nats-jobs",
   "author": "GovSpend",
   "main": "dist/index.js",


### PR DESCRIPTION
Bump version for https://github.com/smartprocure/nats-topology-runner/pull/8